### PR TITLE
Events Definition Relocation

### DIFF
--- a/main.py
+++ b/main.py
@@ -61,5 +61,5 @@ async def on_message(message):
 async def ping(interaction:discord.Interaction) -> None:
     await interaction.response.send_message("pong", ephemeral=True)
 
-if config: run_bot(client, command_tree, config)
+if config: run_bot(client, config)
 


### PR DESCRIPTION
Events are now defined outside the `run_bot()` which removed the need for `command_tree` param and makes it easier to view event definitions. Slash commands are defined below it.